### PR TITLE
[GRANT-79] - Pull Files From CHEFS

### DIFF
--- a/server/src/attachments/attachment.entity.ts
+++ b/server/src/attachments/attachment.entity.ts
@@ -15,4 +15,7 @@ export class Attachment extends CustomBaseEntity {
   // String doesn't work for AxiosResponse type
   @Column({ type: 'bytea', nullable: true })
   data: Buffer;
+
+  @Column({ type: 'varchar', length: '200', nullable: false })
+  originalName: string;
 }

--- a/server/src/attachments/attachment.entity.ts
+++ b/server/src/attachments/attachment.entity.ts
@@ -12,6 +12,7 @@ export class Attachment extends CustomBaseEntity {
   url: string;
 
   // nullable for now
+  // String doesn't work for AxiosResponse type
   @Column({ type: 'bytea', nullable: true })
-  data: string;
+  data: Buffer;
 }

--- a/server/src/common/enums.ts
+++ b/server/src/common/enums.ts
@@ -18,3 +18,9 @@ export enum ApplicationSortOptions {
   SUBMISSION_ID = 'submissionId',
   UPDATED_AT = 'updatedAt',
 }
+
+export enum AxiosResponseTypes {
+  BLOB = 'blob',
+  ARRAY_BUFFER = 'arraybuffer',
+  STREAM = 'stream',
+}

--- a/server/src/database/database.error.ts
+++ b/server/src/database/database.error.ts
@@ -1,0 +1,8 @@
+import { GenericError } from '../common/generic-exception';
+
+export const DatabaseError = {
+  TOKEN_NOT_FOUND: {
+    errorType: 'TOKEN_NOT_FOUND',
+    errorMessage: "Couldn't find the bearer token argument. Please provide it as -- token=<token>.",
+  } as GenericError,
+};

--- a/server/src/database/scripts/sync-chefs-data.service.ts
+++ b/server/src/database/scripts/sync-chefs-data.service.ts
@@ -80,7 +80,7 @@ export class SyncChefsDataService {
       'Content-Type': 'application/x-www-formid-urlencoded',
       Authorization: `Bearer ${token}`,
     };
-    const responseType = AxiosResponseTypes.BLOB;
+    const responseType = AxiosResponseTypes.ARRAY_BUFFER;
     const options = {
       method,
       headers,
@@ -97,6 +97,7 @@ export class SyncChefsDataService {
         id: file.data.id,
         url: file.url,
         data: fileData,
+        originalName: file.originalName,
       } as Attachment;
 
       await this.attachmentService.createOrUpdateAttachment(newAttachmentData);

--- a/server/src/database/scripts/sync-chefs-data.service.ts
+++ b/server/src/database/scripts/sync-chefs-data.service.ts
@@ -78,6 +78,7 @@ export class SyncChefsDataService {
       method,
       headers,
       responseType,
+      responseEncoding: 'binary',
     };
 
     for (const file of files) {
@@ -86,8 +87,9 @@ export class SyncChefsDataService {
       const fileRes = await axios({ ...options, url });
       // const fileData = Buffer.from(fileRes.data, 'utf-8');
       const fileData = fileRes.data;
-      console.log(fileData);
-      // const decodedFileData = iconv.decode(fileRes.data, 'utf-8');
+      const decodedFileData = iconv.decode(fileData, 'UTF-8');
+      // const buff = Buffer.from(fileData).toString();
+      // console.log(decodedFileData);
 
       // Get the file extension
       // const fileExtensionRe = /.*(\.[a-zA-Z0-9]+)$/gm;
@@ -100,7 +102,7 @@ export class SyncChefsDataService {
       const newAttachmentData = {
         id: file.data.id,
         url: file.url,
-        data: fileData,
+        data: '',
       } as Attachment;
 
       await this.attachmentService.createOrUpdateAttachment(newAttachmentData);


### PR DESCRIPTION
Pulls files from CHEFS and populates the data field of the Attachment entity.

Needs the CHEFS user token to work:

`yarn run db:sync-chefs-data -- token=<BEARER TOKEN>`

<img width="998" alt="image" src="https://user-images.githubusercontent.com/102998728/207425186-a4f34f7b-48cc-4d02-943e-117bd06cd4c1.png">


<img width="542" alt="image" src="https://user-images.githubusercontent.com/102998728/207425109-f527939f-fb6a-4ead-a095-3579af2b0672.png">
